### PR TITLE
Fixed bug in signature encoding

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -420,7 +420,7 @@ JWT.prototype.encode = function (str, callback) {
       // Write the data
       cryptoHmacStream.write(str, 'utf8', function () {
         cryptoHmacStream.end();
-        return callback(null, JWT.base64urlEncode(cryptoHmacStream.read()));
+        return callback(null, JWT.base64urlEncode(cryptoHmacStream.read().toString('hex'), 'hex'));
       });
       // out of scope! we already entered a callback
     } catch (e) {
@@ -447,7 +447,7 @@ JWT.prototype.encode = function (str, callback) {
       // Write the data
       cryptoSignStream.write(str, 'utf8', function () {
         cryptoSignStream.end();
-        return callback(null, JWT.base64urlEncode(cryptoSignStream.sign(_this.getPrivateKey())));
+        return callback(null, JWT.base64urlEncode(cryptoSignStream.sign(_this.getPrivateKey()).toString('hex'), 'hex'));
       });
       // out of scope! we already entered a callback
     } catch (e) {
@@ -566,8 +566,8 @@ JWT.base64urlUnescape = function (str) {
   return str.replace(/\-/g, '+').replace(/_/g, '/');
 };
 
-JWT.base64urlEncode = function (str) {
-  return JWT.base64urlEscape(new Buffer(str).toString('base64'));
+JWT.base64urlEncode = function (str, type) {
+  return JWT.base64urlEscape(Buffer.from(str, type || 'utf8').toString('base64'));
 };
 
 JWT.base64urlEscape = function (str) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-async",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "JSON Web Token (JWT) with asynchronicity",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The signature encoding was incompatible with other libraries because the binary signatures were being handled as UTF-8 strings due to the default encoding used by Buffer in the JWT.base64urlEncode() method. The tokens generated by jwt-async could only be used with jwt-async and tokens produced from other libraries would not verify in jwt-async.

This change adds specific encoding to the crypto signature strings to ensure they are handled properly by Buffer which makes the tokens compatible with other JWT libraries and jwt-async can now verify tokens from other libraries.

All tests passed with this change.

One possible issue that could arise is if a token from an older version of jwt-async is used with this patched library.

EDIT: Spoke too soon. The tests on the old versions of nodejs fail, not sure why.